### PR TITLE
Bump golang from 1.17.3-alpine to 1.17.5-alpine (#18) (#19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.3-alpine
+FROM golang:1.17.5-alpine
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Bumps golang from 1.17.3-alpine to 1.17.5-alpine.

---
updated-dependencies:
- dependency-name: golang
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>